### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :to_top_page, only: [:new]
+  before_action :authenticate_user! , except: [:index]
   def index
     @items = Item.all
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :to_top_page, only: [:new]
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :to_top_page, only: [:new]
   before_action :authenticate_user! , except: [:index]
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../price")

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,26 +125,28 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
+      <% @items.each do |item| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outの表示 %>
+          <%# <% unless item.order_id %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <%# <% end %>
           <%# //商品が売れていればsold outの表示 %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +155,12 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items = nil%>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -172,10 +176,11 @@
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
+        <% end  %>
+      <%# </li> %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# //商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
 root to: "items#index"
-resources :items, only: [:new, :create]
+resources :items, only: [:new, :create, :index]
 end


### PR DESCRIPTION
#what
商品一覧機能の実装

＃why
商品を一覧でみたいため

#実装について
「売却済みの商品は、「sold out」の文字が表示されるようになっていること」という実装条件があったのですがこちらの機能は購入機能実装の際に実装するのが好ましいと判断したため後ほどのタスクで実装します。

【gyazo】
  ・ログインの状態ではなくても商品一覧ページをみれる
　https://gyazo.com/d7a104e0b468005c0a6112cb1a0a4596

  ・出品した商品が商品一覧ページに反映される
　https://gyazo.com/cda28d28c11bfb0135403c9d59fc1ca9